### PR TITLE
Make edge color between graph nodes darker

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -50,7 +50,7 @@
   --background-secondary: #eaeaeb;
   --background-secondary-alt: #dbdbdc;
   --background-accent: #fff;
-  --background-modifier-border: #eaeaeb;
+  --background-modifier-border: #dbdbdc;
   --background-modifier-form-field: #fff;
   --background-modifier-form-field-highlighted: #fff;
   --background-modifier-box-shadow: rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Changed the colour for the edges between graph nodes (`--background-modifier-border`) to be slightly darker than the background (`--background-secondary`) so that they visually stand out, even when the cursor is not hovering over a specific node.

Before:
![image](https://user-images.githubusercontent.com/9638116/87902642-78285d00-ca5a-11ea-9c43-ef2be002292e.png)

After:
![image](https://user-images.githubusercontent.com/9638116/87902863-f1c04b00-ca5a-11ea-8cf6-dcc2be5e09fd.png)
