### PR TITLE
Remove unnecessary code token tag background

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -141,7 +141,7 @@ li {
   padding-bottom: 0.5px;
 }
 
-.tag, .tag:hover {
+a.tag, a.tag:hover {
   color: var(--yellow);
   background-color: var(--background-primary-alt);
   padding: 2px 4px;


### PR DESCRIPTION
When using light theme and writing html code in block such as:

```html
<p>Text</p>
```

The hashtag styling was affecting html token tags. I removed unnecessary token tag background color:

Before:
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/725324/116235135-c42cce80-a75d-11eb-9328-ab2eaf0e47b6.png">

After:
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/725324/116235166-cf7ffa00-a75d-11eb-8b5a-856eb682d263.png">

The `#tag` styling is preserved.

